### PR TITLE
Show master branch status badge on main page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 ## Build Status
 
-<img src="https://ci.appveyor.com/api/projects/status/5euy83253gjqdasg?svg=true">
+<img src="https://ci.appveyor.com/api/projects/status/5euy83253gjqdasg/branch/master?svg=true
+">
 
 Table of Contents
 =================


### PR DESCRIPTION
Currently the build status badge is shown for the most recent commit in any branch.

This will now show the master branch only, and it should (in theory) be always green, since commits to the main branch requires all tests to pass.