### PR TITLE
Only code commits to trigger CI checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 
 ## Build Status
 
-<img src="https://ci.appveyor.com/api/projects/status/5euy83253gjqdasg/branch/master?svg=true
-">
+<img src="https://ci.appveyor.com/api/projects/status/5euy83253gjqdasg/branch/master?svg=true">
 
 Table of Contents
 =================

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 ## Build Status
 
-<img src="https://ci.appveyor.com/api/projects/status/5euy83253gjqdasg?svg=true">
+<img src="https://ci.appveyor.com/api/projects/status/5euy83253gjqdasg/branch/master?svg=true
+">
 
 Table of Contents
 =================

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,15 @@
 version: 0.1.{build}
+
 image:
 - Ubuntu1604
 - Visual Studio 2017
+
+only_commits:
+  files:
+    - appveyor.yml
+    - download_and_build_third_party_libs.*
+    - src/
+
 install:
 - cmd: choco install bazel
 - cmd: Powershell.exe -executionpolicy remotesigned -File .\download_and_build_third_party_libs_windows.ps1
@@ -20,9 +28,11 @@ install:
 
     sudo apt-get update && sudo apt-get install bazel
 - sh: ./download_and_build_third_party_libs.sh
+
 build_script:
 - cd src
 # - bazel build --incompatible_package_name_is_a_function=false //automaton/...
+
 test_script:
 - cmd: bazel test --test_size_filters=small --test_tag_filters=-flaky //automaton/tests/...
 - sh: bazel test --test_size_filters=small --incompatible_package_name_is_a_function=false //automaton/tests/...


### PR DESCRIPTION
Currently changing any file including docs/readme/etc. triggers an AppVeyor CI test run.
This makes it so that CI happens only when code is modified.