### PR TITLE
Fix LuaJIT build on MacOS

### DIFF
--- a/download_and_build_third_party_libs.sh
+++ b/download_and_build_third_party_libs.sh
@@ -166,7 +166,11 @@ print_separator "=" 80
 # cd ..
 
 cd LuaJIT
-make
+if $darwin; then
+  make MACOSX_DEPLOYMENT_TARGET=`sw_vers -productVersion`
+else
+  make
+fi
 cd ..
 
 # Build libzmq

--- a/download_and_build_third_party_libs.sh
+++ b/download_and_build_third_party_libs.sh
@@ -59,7 +59,7 @@ function get_archive() {
   echo "  Downloading $filename from $url"
   print_separator "=" 80
 
-  [ ! -f $2 ] && wget $1 -O $2
+  [ ! -f $2 ] && curl -L $1 -o $2
   filesha=$(shasum -a 256 $filename | cut -d' ' -f1)
   if [ $filesha != $sha ]; then
     echo "Error: Wrong hash [$filesha] Expected [$sha]"
@@ -127,13 +127,13 @@ git_repo "https://github.com/orlp/ed25519.git" "ed25519" "7fa6712ef5d581a6981ec2
 
 [ ! -d json-3.1.2 ] && \
   mkdir json-3.1.2 && \
-  wget https://github.com/nlohmann/json/releases/download/v3.2.0/json.hpp -O json-3.1.2/json.hpp
+  curl -L https://github.com/nlohmann/json/releases/download/v3.2.0/json.hpp -o json-3.1.2/json.hpp
 
 [ ! -d sol2 ] && \
   mkdir sol2 && \
   mkdir sol2/single && \
   mkdir sol2/single/sol && \
-  wget https://github.com/ThePhD/sol2/releases/download/v2.20.6/sol.hpp -O sol2/single/sol/sol.hpp
+  curl -L https://github.com/ThePhD/sol2/releases/download/v2.20.6/sol.hpp -o sol2/single/sol/sol.hpp
 
 [ ! -d boost_1_68_0 ] && \
   get_archive "https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.gz" \


### PR DESCRIPTION
LuaJIT doesn't build on Mojave unless the MACOSX version is defined.