### PR TITLE
Fix build script Bazel compatibility issues

### DIFF
--- a/build-and-run-automaton-core.sh
+++ b/build-and-run-automaton-core.sh
@@ -1,5 +1,5 @@
 #/bin/bash
 cd src
 mkdir -p logs
-bazel build -c opt //automaton/core && bazel-bin/automaton/core/core # 2>/dev/null
+bazel build --incompatible_package_name_is_a_function=false -c opt //automaton/core && bazel-bin/automaton/core/core # 2>/dev/null
 #reset


### PR DESCRIPTION
New version of Bazel is not compatible with some third party BUILD rules (e.g. protobufs). This will need to be fixed properly at some point by the owners.