### PR TITLE
build boost w/o embedding version in folder name

### DIFF
--- a/download_and_build_third_party_libs.sh
+++ b/download_and_build_third_party_libs.sh
@@ -138,6 +138,7 @@ git_repo "https://github.com/orlp/ed25519.git" "ed25519" "7fa6712ef5d581a6981ec2
 [ ! -d boost_1_68_0 ] && \
   get_archive "https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.gz" \
   "boost_1_68_0.tar.gz" "da3411ea45622579d419bfda66f45cd0f8c32a181d84adfa936f5688388995cf"
+[ -d boost_1_68_0 ] && mv boost_1_68_0 boost
 
 [ ! -d zlib-1.2.11 ] && get_archive "https://zlib.net/zlib-1.2.11.tar.gz" \
   "zlib-1.2.11.tar.gz" "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1"
@@ -212,7 +213,7 @@ print_separator "=" 80
 echo "  BUILDING boost"
 print_separator "=" 80
 
-cd boost_1_68_0
+cd boost
 [ ! -f b2 ] && ./bootstrap.sh
 [ ! -d stage ] && ./b2 \
   --with-filesystem --with-system --with-iostreams \

--- a/download_and_build_third_party_libs_windows.ps1
+++ b/download_and_build_third_party_libs_windows.ps1
@@ -156,18 +156,19 @@ echo ("="*80)
 
 if ($env:APPVEYOR) {
   echo "Moving pre-installed boost into our tree"
-  Move-Item -Path C:\Libraries\boost_1_67_0 -Destination .\boost_1_68_0
-  cd boost_1_68_0
+  Move-Item -Path C:\Libraries\boost_1_67_0 -Destination .\boost
+  cd boost
   mkdir stage
   cd stage
   Move-Item -Path ..\lib64-msvc-14.1 -Destination lib
   cd ..\..
 } else {
-  if(!(Test-Path -Path .\boost_1_68_0)) {
+  if(!(Test-Path -Path .\boost)) {
       Get-Archive "https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.zip" `
     "boost_1_68_0.zip" "3B1DB0B67079266C40B98329D85916E910BBADFC3DB3E860C049056788D4D5CD"
   }
-  cd boost_1_68_0
+  Move-Item -Path .\boost_1_68_0 -Destination .\boost
+  cd boost
   .\bootstrap.bat
   .\b2 --with-filesystem --with-system --with-iostreams cxxstd=14 link=static stage
   cd ..

--- a/src/WORKSPACE
+++ b/src/WORKSPACE
@@ -98,6 +98,6 @@ local_repository(
 
 new_local_repository(
   name = "localboost",
-  path = "local_third_party/boost_1_68_0",
+  path = "local_third_party/boost",
   build_file = "third_party/localboost.BUILD",
 )


### PR DESCRIPTION
Removing hardcoded boost version as it is misleading, when different targets use different versions. e.g. AppVeyor does not come with 1.68 installed but only 1.67.