### PR TITLE
Network refactor

### DIFF
--- a/src/automaton/core/core.cc
+++ b/src/automaton/core/core.cc
@@ -114,8 +114,8 @@ int main(int argc, char* argv[]) {
   string automaton_ascii_logo(automaton_ascii_logo_cstr);
   string_replace(&automaton_ascii_logo, "@", "\x1b[38;5;");
   auto core_factory = std::make_shared<protobuf_factory>();
-  node::register_node_type("lua", [](const std::string& id, const std::string& proto_id)->std::unique_ptr<node> {
-      return std::unique_ptr<node>(new lua_node(id, proto_id));
+  node::register_node_type("lua", [](const std::string& id, const std::string& proto_id)->std::shared_ptr<node> {
+      return std::shared_ptr<node>(new lua_node(id, proto_id));
     });
 
 {
@@ -128,9 +128,8 @@ int main(int argc, char* argv[]) {
 
   node_type.set(sol::call_constructor,
     sol::factories(
-    [&](const std::string& id, std::string proto) -> unique_ptr<lua_node> {
-      auto n = node::create("lua", id, proto);
-      return unique_ptr<lua_node>(reinterpret_cast<lua_node*>(n.release()));
+    [&](const std::string& id, std::string proto) -> std::shared_ptr<lua_node> {
+      return std::dynamic_pointer_cast<lua_node>(node::create("lua", id, proto));
     }));
 
   // Bind this node to its own Lua state.
@@ -195,9 +194,8 @@ int main(int argc, char* argv[]) {
     return sol::as_table(node::list_nodes());
   });
 
-  script.set_function("get_node", [&](const std::string& node_id) {
-    node* n = node::get_node(node_id);
-    return reinterpret_cast<lua_node*>(n);
+  script.set_function("get_node", [&](const std::string& node_id) -> std::shared_ptr<lua_node> {
+    return std::dynamic_pointer_cast<lua_node>(node::get_node(node_id));
   });
 
   script.set_function("launch_node", [&](std::string node_id, std::string protocol_id, std::string address) {

--- a/src/automaton/core/core.lua
+++ b/src/automaton/core/core.lua
@@ -16,6 +16,8 @@ history_add("list_nodes()")
 hints_add("list_nodes()")
 history_add("get_node()")
 hints_add("get_node()")
+history_add("remove_node()")
+hints_add("remove_node()")
 
 history_add("add_peers()")
 hints_add("add_peers()")

--- a/src/automaton/core/network/acceptor.cc
+++ b/src/automaton/core/network/acceptor.cc
@@ -4,14 +4,15 @@ namespace automaton {
 namespace core {
 namespace network {
 
-acceptor::acceptor(acceptor_id id_, acceptor::acceptor_handler* handler_):handler(handler_), id(id_) {}
+acceptor::acceptor(acceptor_id id_, std::shared_ptr<acceptor::acceptor_handler> handler_):handler(handler_), id(id_) {}
 
 acceptor_id acceptor::get_id() {
   return id;
 }
 
 std::shared_ptr<acceptor> acceptor::create(const std::string& type, acceptor_id id, const std::string& address,
-    acceptor::acceptor_handler* handler, connection::connection_handler* connections_handler) {
+    std::shared_ptr<acceptor::acceptor_handler> handler,
+    std::shared_ptr<connection::connection_handler> connections_handler) {
   auto it = acceptor_factory.find(type);
   if (it == acceptor_factory.end()) {
     return NULL;

--- a/src/automaton/core/network/acceptor.h
+++ b/src/automaton/core/network/acceptor.h
@@ -81,6 +81,11 @@ class acceptor {
   virtual void start_accepting() = 0;
 
   /**
+    The acceptor starts to listen for incoming connections.
+  */
+  virtual void stop_accepting() = 0;
+
+  /**
     @returns the acceptor's address
   */
   virtual std::string get_address() const = 0;
@@ -115,10 +120,10 @@ class acceptor {
     @returns object from the specified class. If no such class type was registered, empty ptr will be returned.
   */
   static std::shared_ptr<acceptor> create(const std::string& type, acceptor_id id, const std::string& address,
-      acceptor_handler* handler_, connection::connection_handler* connections_handler);
+      std::shared_ptr<acceptor_handler> handler_, std::shared_ptr<connection::connection_handler> connections_handler);
 
   typedef std::shared_ptr<acceptor> (*factory_function)(acceptor_id id, const std::string& address,
-      acceptor_handler* handler_, connection::connection_handler* connections_handler);
+      std::shared_ptr<acceptor_handler> handler_, std::shared_ptr<connection::connection_handler> connections_handler);
 
   /**
     Registers acceptor implementation.
@@ -139,9 +144,9 @@ class acceptor {
       @see acceptor_handler
     @param[in] handler_ pointer to an acceptor_handler
   */
-  acceptor(acceptor_id id, acceptor_handler* handler_);
+  acceptor(acceptor_id id, std::shared_ptr<acceptor_handler> handler_);
 
-  acceptor_handler* handler;
+  std::shared_ptr<acceptor_handler> handler;
   acceptor_id id;
 
  private:

--- a/src/automaton/core/network/acceptor.h
+++ b/src/automaton/core/network/acceptor.h
@@ -81,7 +81,7 @@ class acceptor {
   virtual void start_accepting() = 0;
 
   /**
-    The acceptor starts to listen for incoming connections.
+    The acceptor stops to listen for incoming connections.
   */
   virtual void stop_accepting() = 0;
 

--- a/src/automaton/core/network/connection.cc
+++ b/src/automaton/core/network/connection.cc
@@ -4,11 +4,11 @@ namespace automaton {
 namespace core {
 namespace network {
 
-connection::connection(connection_id id_, connection::connection_handler* handler_):
+connection::connection(connection_id id_, std::shared_ptr<connection::connection_handler> handler_):
     handler(handler_), id(id_) {}
 
 std::shared_ptr<connection> connection::create(const std::string& type, connection_id id, const std::string& address,
-    connection::connection_handler* handler) {
+    std::shared_ptr<connection::connection_handler> handler) {
   auto it = connection_factory.find(type);
   if (it == connection_factory.end()) {
     return nullptr;

--- a/src/automaton/core/network/connection.h
+++ b/src/automaton/core/network/connection.h
@@ -60,7 +60,8 @@ class connection {
       @param[in] id the identifier of the read operation
         @see connection::async_read
     */
-    virtual void on_message_received(connection_id c, char* buffer, uint32_t bytes_read, uint32_t id) = 0;
+    virtual void on_message_received(connection_id c, std::shared_ptr<char> buffer, uint32_t bytes_read,
+        uint32_t id) = 0;
 
     /**
       Will be invoked to notify the user that a message was successfully sent or an error occured.
@@ -132,7 +133,8 @@ class connection {
     @param[in] id given by the user to identify this specific read call. It will be used from the handler when
       on_message_received is called. @see connection_handler::on_message_received
   */
-  virtual void async_read(char* buffer, uint32_t buffer_size, uint32_t num_bytes = 0, uint32_t id = 0) = 0;
+  virtual void async_read(std::shared_ptr<char> buffer, uint32_t buffer_size, uint32_t num_bytes = 0,
+      uint32_t id = 0) = 0;
 
   /**
     @return the connection id
@@ -178,10 +180,10 @@ class connection {
 
   */
   static std::shared_ptr<connection> create(const std::string& type, connection_id id, const std::string& address,
-      connection_handler* handler);
+      std::shared_ptr<connection_handler> handler);
 
   typedef std::shared_ptr<connection>
-      (*factory_function)(connection_id id, const std::string& address, connection_handler* handler);
+      (*factory_function)(connection_id id, const std::string& address, std::shared_ptr<connection_handler> handler);
 
   /**
     Registers connection implementation.
@@ -201,7 +203,7 @@ class connection {
     invoked the function. @see connection_handler
   @param[in] handler_ pointer to an connection_handler
   */
-  connection(connection_id id, connection_handler* handler_);
+  connection(connection_id id, std::shared_ptr<connection_handler> handler_);
 
   /**
     Handler object that must be set so the client could be informed for events.
@@ -209,7 +211,7 @@ class connection {
     client will not have access to events information like connect/ disconnect,
     received messages or an error that happend.
   */
-  connection_handler* handler;
+  std::shared_ptr<connection_handler> handler;
   connection_id id;
 
  private:

--- a/src/automaton/core/network/simulated_connection.cc
+++ b/src/automaton/core/network/simulated_connection.cc
@@ -294,7 +294,13 @@ uint32_t simulation::process(uint64_t time_) {
       for (auto& t : tasks.at(current_time)) {
         events_processed++;
         tasks_mutex.unlock();
-        t();
+        try {
+          t();
+        } catch (const std::exception& e) {
+          LOG(ERROR) << e.what();
+        } catch (...) {
+          LOG(ERROR) << "Error occured";
+        }
         tasks_mutex.lock();
       }
       tasks.erase(current_time);

--- a/src/automaton/core/network/simulated_connection.h
+++ b/src/automaton/core/network/simulated_connection.h
@@ -150,7 +150,7 @@ class simulated_connection: public connection, public std::enable_shared_from_th
   uint32_t remote_connection_id;
 
   struct incoming_packet {
-    char* buffer;
+    std::shared_ptr<char> buffer;
     uint32_t buffer_size;
     uint32_t expect_to_read;
     uint32_t id;
@@ -174,7 +174,7 @@ class simulated_connection: public connection, public std::enable_shared_from_th
   std::queue<std::string> receive_buffer;
   std::mutex recv_buf_mutex;
 
-  simulated_connection(connection_id id, const std::string& address_, connection_handler* handler_);
+  simulated_connection(connection_id id, const std::string& address_, std::shared_ptr<connection_handler> handler_);
 
   ~simulated_connection();
 
@@ -188,7 +188,7 @@ class simulated_connection: public connection, public std::enable_shared_from_th
 
   void async_send(const std::string& message, uint32_t message_id);
 
-  void async_read(char* buffer, uint32_t buffer_size, uint32_t num_bytes, uint32_t id);
+  void async_read(std::shared_ptr<char> buffer, uint32_t buffer_size, uint32_t num_bytes, uint32_t id);
 
   void handle_read();
   void handle_send();
@@ -201,7 +201,7 @@ class simulated_connection: public connection, public std::enable_shared_from_th
 
   uint32_t get_lag() const;
 
-  connection_handler* get_handler();
+  std::shared_ptr<connection_handler> get_handler();
 
   void set_time_stamp(uint32_t t);
 
@@ -235,16 +235,18 @@ class simulated_acceptor: public acceptor, public std::enable_shared_from_this<s
   uint32_t address;
   std::string original_address;
   acceptor_params parameters;
-  connection::connection_handler* accepted_connections_handler;
+  std::shared_ptr<connection::connection_handler> accepted_connections_handler;
 
-  simulated_acceptor(acceptor_id id, const std::string& address_, acceptor::acceptor_handler*
-      handler_, connection::connection_handler* accepted_connections_handler);
+  simulated_acceptor(acceptor_id id, const std::string& address_, std::shared_ptr<acceptor::acceptor_handler>
+      handler_, std::shared_ptr<connection::connection_handler> accepted_connections_handler);
 
   ~simulated_acceptor();
 
   bool init();
 
   void start_accepting();
+
+  void stop_accepting();
 
   state get_state() const;
 
@@ -254,7 +256,7 @@ class simulated_acceptor: public acceptor, public std::enable_shared_from_this<s
 
   bool parse_address(const std::string& address_, acceptor_params* params, uint32_t* parsed_address);
 
-  acceptor_handler* get_handler();
+  std::shared_ptr<acceptor_handler> get_handler();
 
  private:
   acceptor::state acceptor_state;

--- a/src/automaton/core/network/tcp_implementation.h
+++ b/src/automaton/core/network/tcp_implementation.h
@@ -54,7 +54,7 @@ class tcp_connection: public connection, public std::enable_shared_from_this<tcp
 
     @param[in] address_ string representing the address of the connection - ip:port
   */
-  tcp_connection(connection_id id, const std::string& address_, connection_handler* handler_);
+  tcp_connection(connection_id id, const std::string& address_, std::shared_ptr<connection_handler> handler_);
 
   /**
     Constructor that should be used **ONLY** from the acceptor. It is used when there is a connection request and
@@ -70,7 +70,7 @@ class tcp_connection: public connection, public std::enable_shared_from_this<tcp
     @param[in] socket_ the boost::asio::ip::tcp::socket on which the new connection was accepted.
   */
   tcp_connection(connection_id id, const std::string& address_, const boost::asio::ip::tcp::socket& socket_,
-      connection_handler* handler_);
+      std::shared_ptr<connection_handler> handler_);
 
   /**
     Destructor.
@@ -128,7 +128,7 @@ class tcp_connection: public connection, public std::enable_shared_from_this<tcp
     If an error occures during sending, on_connection_error() will be called with status, containing the error.
     If the error is boost::asio::error::eof (meaning the other peer has disconnected), disconnect() will be called too.
   */
-  void async_read(char* buffer, uint32_t buffer_size, uint32_t num_bytes, uint32_t id);
+  void async_read(std::shared_ptr<char> buffer, uint32_t buffer_size, uint32_t num_bytes, uint32_t id);
 
   /**
     This function can be called to disconnect peer. To reconnect, connect() should be called. Handler's
@@ -140,7 +140,7 @@ class tcp_connection: public connection, public std::enable_shared_from_this<tcp
     This function is used to change the handler. It may be necessary when a connection is created from the acceptor
     and the default handler (the one passed to the acceptor) needs to be changed.
   */
-  void add_handler(connection_handler* handler_);
+  void add_handler(std::shared_ptr<connection_handler> handler_);
 
   std::string get_address() const;
 
@@ -163,8 +163,8 @@ class tcp_acceptor:public acceptor, public std::enable_shared_from_this<tcp_acce
     @see acceptor::create
     @see acceptor::factory_function
   */
-  tcp_acceptor(acceptor_id id, const std::string& address, acceptor_handler* handler_,
-      connection::connection_handler* connections_handler);
+  tcp_acceptor(acceptor_id id, const std::string& address, std::shared_ptr<acceptor_handler> handler_,
+      std::shared_ptr<connection::connection_handler> connections_handler);
 
   /**
     Destructor.
@@ -206,13 +206,15 @@ class tcp_acceptor:public acceptor, public std::enable_shared_from_this<tcp_acce
   */
   void start_accepting();
 
+  void stop_accepting();
+
   std::string get_address() const;
 
   acceptor::state get_state() const;
 
  private:
   boost::asio::ip::tcp::acceptor asio_acceptor;
-  connection::connection_handler* accepted_connections_handler;
+  std::shared_ptr<connection::connection_handler> accepted_connections_handler;
   acceptor::state acceptor_state;
   mutable std::mutex state_mutex;
   std::string address;

--- a/src/automaton/core/node/lua_node/lua_node.h
+++ b/src/automaton/core/node/lua_node/lua_node.h
@@ -28,11 +28,6 @@ class lua_node : public node {
 
   void init();
 
-  void init_bindings(std::vector<automaton::core::data::schema*> schemas,
-                     std::vector<std::string> lua_scripts,
-                     std::vector<std::string> wire_msgs,
-                     std::vector<std::string> commands);
-
   void script(const std::string& command, std::promise<std::string>* result);
 
   uint32_t find_message_id(const std::string& name) {
@@ -56,6 +51,11 @@ class lua_node : public node {
   std::unordered_map<uint32_t, sol::protected_function> script_on_msg;
   std::unordered_map<std::string, sol::protected_function> script_on_cmd;
   sol::protected_function script_on_debug_html;
+
+  void init_bindings(std::vector<automaton::core::data::schema*> schemas,
+                     std::vector<std::string> lua_scripts,
+                     std::vector<std::string> wire_msgs,
+                     std::vector<std::string> commands);
 
   // Script handler functions
   void s_on_blob_received(peer_id id, const std::string& blob);

--- a/src/automaton/core/node/node.h
+++ b/src/automaton/core/node/node.h
@@ -32,14 +32,15 @@ struct peer_info {
 };
 
 class node: public network::connection::connection_handler,
-            public network::acceptor::acceptor_handler {
+            public network::acceptor::acceptor_handler,
+            public std::enable_shared_from_this<node> {
  public:
-  typedef std::unique_ptr<node> (*factory_function)(const std::string& id, const std::string& proto_id);
-  static std::unique_ptr<node> create(const std::string& type, const std::string& id, const std::string& proto_id);
+  typedef std::shared_ptr<node> (*factory_function)(const std::string& id, const std::string& proto_id);
+  static std::shared_ptr<node> create(const std::string& type, const std::string& id, const std::string& proto_id);
   static void register_node_type(const std::string& type, factory_function func);
 
   static std::vector<std::string> list_nodes();
-  static node* get_node(const std::string& node_id);
+  static std::shared_ptr<node> get_node(const std::string& node_id);
   static bool launch_node(const std::string& node_type, const std::string& node_id, const std::string& protocol_id,
       const std::string& address);
   static void remove_node(const std::string& node_id);
@@ -52,9 +53,9 @@ class node: public network::connection::connection_handler,
 
   bool get_worker_stop_signal();
 
-  std::string get_id();
+  std::string get_id() const;
 
-  std::string get_protocol_id();
+  std::string get_protocol_id() const;
 
   peer_info get_peer_info(peer_id id);
 
@@ -107,7 +108,7 @@ class node: public network::connection::connection_handler,
 
  private:
   static std::map<std::string, factory_function> node_factory;
-  static std::unordered_map<std::string, std::unique_ptr<node> > nodes;
+  static std::unordered_map<std::string, std::shared_ptr<node> > nodes;
   peer_id peer_ids;
 
   uint32_t update_time_slice;
@@ -137,7 +138,7 @@ class node: public network::connection::connection_handler,
 
   // Inherited handlers' functions
 
-  void on_message_received(peer_id c, char* buffer, uint32_t bytes_read, uint32_t id);
+  void on_message_received(peer_id c, std::shared_ptr<char> buffer, uint32_t bytes_read, uint32_t id);
 
   void on_message_sent(peer_id c, uint32_t id, const common::status& s);
 

--- a/src/automaton/core/rpc_server_core_test.cc
+++ b/src/automaton/core/rpc_server_core_test.cc
@@ -10,8 +10,8 @@ std::shared_ptr<connection> connection_c;
 
 class client_handler:public connection::connection_handler {
  public:
-  void on_message_received(connection_id c, char* buffer, uint32_t bytes_read, uint32_t mid) {
-    std::string message = std::string(buffer, bytes_read);
+  void on_message_received(connection_id c, std::shared_ptr<char> buffer, uint32_t bytes_read, uint32_t mid) {
+    std::string message = std::string(buffer.get(), bytes_read);
     std::cout << "Message \n\"" << message << "\"\nreceived from server" << std::endl;
     connection_c->async_read(buffer, 256, 0, 0);
   }
@@ -36,12 +36,12 @@ class client_handler:public connection::connection_handler {
   }
 };
 
-char* buffer_c = new char[256];
+std::shared_ptr<char> buffer_c = std::shared_ptr<char>(new char[256], std::default_delete<char[]>());
 
-client_handler handler_c;
+std::shared_ptr<client_handler> handler_c;
 
 void client() {
-  connection_c = connection::create("tcp", 1, SERVER_ADDRESS, &handler_c);
+  connection_c = connection::create("tcp", 1, SERVER_ADDRESS, std::move(handler_c));
   if (connection_c->init()) {
     std::cout << "Connection init was successful!" << std::endl;
     connection_c -> connect();
@@ -70,6 +70,5 @@ int main(int argc, char* argv[]) {
   automaton::core::network::tcp_init();
   client();
   automaton::core::network::tcp_release();
-  delete [] buffer_c;
   return 0;
 }

--- a/src/automaton/core/testnet/testnet.cc
+++ b/src/automaton/core/testnet/testnet.cc
@@ -76,7 +76,7 @@ void testnet::connect(std::unordered_map<uint32_t, std::vector<uint32_t> > peers
 
   for (auto it = peers_list.begin(); it != peers_list.end(); it++) {
     std::string nid = id + std::to_string(it->first);
-    automaton::core::node::node* n = automaton::core::node::node::get_node(nid);
+    std::shared_ptr<automaton::core::node::node> n = automaton::core::node::node::get_node(nid);
     if (n == nullptr) {
       LOG(ERROR) << "No such node: " << nid;
       continue;

--- a/src/automaton/tests/network/rpc_server_test.cc
+++ b/src/automaton/tests/network/rpc_server_test.cc
@@ -20,8 +20,8 @@ class test_server_handler: public server::server_handler {
 
 class client_handler:public connection::connection_handler {
  public:
-  void on_message_received(connection_id c, char* buffer, uint32_t bytes_read, uint32_t mid) {
-    std::string message = std::string(buffer, bytes_read);
+  void on_message_received(connection_id c, std::shared_ptr<char> buffer, uint32_t bytes_read, uint32_t mid) {
+    std::string message = std::string(buffer.get(), bytes_read);
     LOG(INFO) << "Message \"" << message << "\" received from server";
     EXPECT_EQ(message, "requestresponse");
     // connection_c->async_read(buffer, 256, 0, 0);
@@ -47,12 +47,12 @@ class client_handler:public connection::connection_handler {
   }
 };
 
-char* buffer_c = new char[256];
+std::shared_ptr<char> buffer_c = std::shared_ptr<char>(new char[256], std::default_delete<char[]>());
 
-client_handler handler_c;
+std::shared_ptr<client_handler> handler_c;
 
 void client() {
-  connection_c = connection::create("tcp", 1, SERVER_ADDRESS, &handler_c);
+  connection_c = connection::create("tcp", 1, SERVER_ADDRESS, std::move(handler_c));
   if (connection_c->init()) {
     LOG(DEBUG) << "Connection init was successful!";
     connection_c -> connect();
@@ -75,5 +75,4 @@ TEST(rpc_echo, basic_test) {
   client();
   rpc.stop();
   automaton::core::network::tcp_release();
-  delete [] buffer_c;
 }

--- a/src/automaton/tests/network/sim_test.cc
+++ b/src/automaton/tests/network/sim_test.cc
@@ -21,13 +21,13 @@ uint32_t get_new_id() {
   return ++cids;
 }
 
-char* bufferC = new char[256];
+std::shared_ptr<char> bufferC = std::shared_ptr<char>(new char[256], std::default_delete<char[]>());
 
 std::shared_ptr<automaton::core::network::simulation> sim;
 class handler: public connection::connection_handler {
  public:
-  void on_message_received(connection_id c, char* buffer, uint32_t bytes_read, uint32_t mid) {
-    std::string message = std::string(buffer, bytes_read);
+  void on_message_received(connection_id c, std::shared_ptr<char> buffer, uint32_t bytes_read, uint32_t mid) {
+    std::string message = std::string(buffer.get(), bytes_read);
     LOG(INFO) << "Message \"" << message << "\" received from " << c;
     if (message.compare("Thank you!")) {
       connections[c]->async_send("Thank you!", counter++);
@@ -68,7 +68,7 @@ class lis_handler: public acceptor::acceptor_handler {
   void on_connected(acceptor_id a, std::shared_ptr<connection> c, const std::string& address) {
     LOG(INFO) << "Accepted connection from: " << address;
     connections[c->get_id()] = c;
-    char* buffer = new char[256];
+    std::shared_ptr<char> buffer = std::shared_ptr<char>(new char[256], std::default_delete<char[]>());
     c->async_read(buffer, 256, 0);
   }
   void on_acceptor_error(acceptor_id a, const status& s) {
@@ -76,10 +76,12 @@ class lis_handler: public acceptor::acceptor_handler {
   }
 };
 
-handler handlerC, handlerA;
+std::shared_ptr<handler> handlerC = std::make_shared<handler>();
+std::shared_ptr<handler> handlerA = std::make_shared<handler>();
 
 void func() {
-  std::shared_ptr<connection> connection_c = connection::create("sim", get_new_id(), "10:100:10:1", &handlerC);
+  std::shared_ptr<connection> connection_c =
+      connection::create("sim", get_new_id(), "10:100:10:1", std::move(handlerC));
   if (connection_c->init()) {
     connections[connection_c->get_id()] = connection_c;
     LOG(DEBUG) << "Connection init was successful!";
@@ -110,8 +112,8 @@ void func() {
 
 int main() {
   sim = automaton::core::network::simulation::get_simulator();
-  lis_handler lis_handler;
-  std::shared_ptr<acceptor> acceptorB = acceptor::create("sim", 1, "1:10:1", &lis_handler, &handlerA);
+  std::shared_ptr<lis_handler> l_handler = std::make_shared<lis_handler>();
+  std::shared_ptr<acceptor> acceptorB = acceptor::create("sim", 1, "1:10:1", std::move(l_handler), std::move(handlerA));
   if (acceptorB->init()) {
     LOG(DEBUG) << "Acceptor init was successful!";
     acceptorB->start_accepting();
@@ -124,7 +126,6 @@ int main() {
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
   t.join();
-  delete [] bufferC;
   connections.clear();
   return 0;
 }

--- a/src/automaton/tests/testnet/BUILD
+++ b/src/automaton/tests/testnet/BUILD
@@ -13,17 +13,17 @@ cc_test (
   ],
 )
 
-#cc_test (
-#  name = "testnet_simulation",
-#  srcs = ["test_simulation.cc",],
-#  size = "medium",
-#  data = ["testproto",],
-#  deps = [
-#    "//automaton/core/network:simulated_connection",
-#    "//automaton/core/smartproto",
-#    "//automaton/core/node",
-#    "//automaton/core/node/lua_node",
-#    "//automaton/core/testnet",
-#    "@gtest//:gtest_main",
-#  ],
-#)
+cc_test (
+  name = "testnet_simulation",
+  srcs = ["test_simulation.cc",],
+  size = "medium",
+  data = ["testproto",],
+  deps = [
+    "//automaton/core/network:simulated_connection",
+    "//automaton/core/smartproto",
+    "//automaton/core/node",
+    "//automaton/core/node/lua_node",
+    "//automaton/core/testnet",
+    "@gtest//:gtest_main",
+  ],
+)

--- a/src/automaton/tests/testnet/test_localhost.cc
+++ b/src/automaton/tests/testnet/test_localhost.cc
@@ -48,7 +48,7 @@ TEST(testnet, test_all) {
 
   std::string result2 = node::get_node("testnet_3")->process_cmd("get_heard_of", "");
   msg2->deserialize_message(result2);
-  // Nodes should have heard of all 5 peers
+  
   EXPECT_EQ(msg2->get_repeated_field_size(1), 5);
 
   // Sort nodes names

--- a/src/automaton/tests/testnet/test_localhost.cc
+++ b/src/automaton/tests/testnet/test_localhost.cc
@@ -15,8 +15,8 @@ using automaton::core::smartproto::smart_protocol;
 using automaton::core::testnet::testnet;
 
 TEST(testnet, test_all) {
-  node::register_node_type("lua", [](const std::string& id, const std::string& proto_id)->std::unique_ptr<node> {
-      return std::unique_ptr<node>(new lua_node(id, proto_id));
+  node::register_node_type("lua", [](const std::string& id, const std::string& proto_id)->std::shared_ptr<node> {
+      return std::shared_ptr<node>(new lua_node(id, proto_id));
     });
 
   EXPECT_EQ(smart_protocol::load("chat", "automaton/tests/testnet/testproto/"), true);

--- a/src/automaton/tests/testnet/test_localhost.cc
+++ b/src/automaton/tests/testnet/test_localhost.cc
@@ -48,7 +48,7 @@ TEST(testnet, test_all) {
 
   std::string result2 = node::get_node("testnet_3")->process_cmd("get_heard_of", "");
   msg2->deserialize_message(result2);
-  
+
   EXPECT_EQ(msg2->get_repeated_field_size(1), 5);
 
   // Sort nodes names

--- a/src/automaton/tests/testnet/test_localhost.cc
+++ b/src/automaton/tests/testnet/test_localhost.cc
@@ -63,7 +63,7 @@ TEST(testnet, test_all) {
 
   testnet::destroy_testnet("testnet");
   EXPECT_EQ(testnet::list_testnets().size(), 0);
-
   EXPECT_EQ(node::list_nodes().size(), 0);
+
   automaton::core::network::tcp_release();
 }

--- a/src/automaton/tests/testnet/test_simulation.cc
+++ b/src/automaton/tests/testnet/test_simulation.cc
@@ -15,8 +15,8 @@ using automaton::core::smartproto::smart_protocol;
 using automaton::core::testnet::testnet;
 
 TEST(testnet, test_all) {
-  node::register_node_type("lua", [](const std::string& id, const std::string& proto_id)->std::unique_ptr<node> {
-      return std::unique_ptr<node>(new lua_node(id, proto_id));
+  node::register_node_type("lua", [](const std::string& id, const std::string& proto_id)->std::shared_ptr<node> {
+      return std::shared_ptr<node>(new lua_node(id, proto_id));
     });
 
   EXPECT_EQ(smart_protocol::load("chat", "automaton/tests/testnet/testproto/"), true);


### PR DESCRIPTION
* connection and acceptor handler are now shared instead of raw pointers
* data buffers in connection are also shared pointers
* disconnect is called for all connections in node when remove_node is called to ensure node deletion
* tasks in simulation are rewritten to use weak_ptr<handler>