### PR TITLE
Fix cashing issues for Windows in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,7 +64,8 @@ for:
   - src\local_third_party\g3log -> download_and_build_third_party_libs_windows.ps1
   - src\local_third_party\JUCE -> download_and_build_third_party_libs_windows.ps1
   - src\local_third_party\zlib-1.2.11.zip -> download_and_build_third_party_libs_windows.ps1
-  - src\local_third_party\*.zip -> download_and_build_third_party_libs_windows.ps1
+  - src\local_third_party\g3log-1.3.2.zip -> download_and_build_third_party_libs_windows.ps1
+  - src\local_third_party\bzip2-1.0.6.zip -> download_and_build_third_party_libs_windows.ps1
 
 install:
 # - cmd: choco install bazel


### PR DESCRIPTION
cache paths don't seem to understand wildcards :(