### PR TITLE
mine key & claimSlot + error handling/cleanup

### DIFF
--- a/contracts/koh/contracts/KingAutomaton.sol
+++ b/contracts/koh/contracts/KingAutomaton.sol
@@ -192,6 +192,10 @@ contract KingAutomaton {
     return mask;
   }
 
+  function getMinDifficulty() public view returns(uint256) {
+    return minDifficulty;
+  }
+
   function getClaimed() public view returns(uint256) {
     return numTakeOvers;
   }

--- a/src/automaton/core/interop/ethereum/eth_contract_curl.cc
+++ b/src/automaton/core/interop/ethereum/eth_contract_curl.cc
@@ -106,11 +106,13 @@ eth_contract::eth_contract(const std::string& server, const std::string& address
   }
   curl = curl_easy_init();
   if (curl) {
+    list = curl_slist_append(list, "Content-Type: application/json");
     curl_easy_setopt(curl, CURLOPT_URL, server.c_str());
     curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, curl_err_buf);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, curl_callback);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &message);
     curl_easy_setopt(curl, CURLOPT_ENCODING, "gzip");
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, list);
 
     // DEBUG
     // curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
@@ -120,6 +122,7 @@ eth_contract::eth_contract(const std::string& server, const std::string& address
 
 eth_contract::~eth_contract() {
   if (curl) {
+    curl_slist_free_all(list);
     curl_easy_cleanup(curl);
   }
 }
@@ -173,8 +176,8 @@ status eth_contract::handle_message() {
   try {
     ss >> j;
   } catch (const std::exception& e) {
-    LOG(ERROR) << "Invalid JSON!\n" + e.what();
-    return status::internal("Invalid JSON!\n" + e.what());
+    LOG(ERROR) << "Invalid JSON!\n" << e.what();
+    return status::internal(e.what());
   }
   message = "";
 

--- a/src/automaton/core/interop/ethereum/eth_contract_curl.cc
+++ b/src/automaton/core/interop/ethereum/eth_contract_curl.cc
@@ -170,7 +170,12 @@ status eth_contract::handle_message() {
   json j;
   uint32_t result_call_id;
   std::stringstream ss(message);
-  ss >> j;
+  try {
+    ss >> j;
+  } catch (const std::exception& e) {
+    LOG(ERROR) << "Invalid JSON!\n" + e.what();
+    return status::internal("Invalid JSON!\n" + e.what());
+  }
   message = "";
 
   if (j.find("id") != j.end() && j["id"].is_number()) {

--- a/src/automaton/core/interop/ethereum/eth_contract_curl.h
+++ b/src/automaton/core/interop/ethereum/eth_contract_curl.h
@@ -71,6 +71,7 @@ class eth_contract: public std::enable_shared_from_this<eth_contract> {
   std::string address;  // ETH address of the contract
   nlohmann::json abi;
   std::unordered_map<std::string, std::pair<std::string, bool> > signatures;  // function signatures
+  struct curl_slist *list = NULL;
 
   CURL *curl;
   CURLcode res;

--- a/src/automaton/core/interop/ethereum/eth_contract_curl_test.cc
+++ b/src/automaton/core/interop/ethereum/eth_contract_curl_test.cc
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <fstream>
 #include <iostream>
 #include <memory>

--- a/src/automaton/core/interop/ethereum/eth_contract_curl_test.cc
+++ b/src/automaton/core/interop/ethereum/eth_contract_curl_test.cc
@@ -36,8 +36,6 @@ static const char* ADDRESS = "0x2a9fe9D9b0dae89C48b8B8F4E008E17f1A1ED4A6";
 // static const char* CONTRACT_ADDR = "...";
 // static const char* ADDRESS = "0x5a0b54d5dc17e0aadc383d2db43b0a0d3e029c4c";
 
-static const std::string BIN_ADDRESS = hex2bin(std::string(24, '0') + std::string(ADDRESS+2));
-
 static const char* PRIVATE_KEY = "56aac550d97013a8402c98e3b2aeb20482d19f142a67022d2ab357eb8bb673b0";
 // static const char* PRIVATE_KEY = "11937405a1975b68ff0e0fc7e3eedcf21e953113b35f95af30839b44b4960c99";
 
@@ -50,6 +48,8 @@ void callback_func(const automaton::core::common::status& s, const std::string& 
 }
 
 int main() {
+  std::string BIN_ADDRESS = hex2bin(std::string(24, '0') + std::string(ADDRESS+2));
+
   // std::string url, contract_addr;
   // std::cout << "Enter URL: ";
   // std::cin >> url;

--- a/src/automaton/core/interop/ethereum/eth_contract_curl_test.cc
+++ b/src/automaton/core/interop/ethereum/eth_contract_curl_test.cc
@@ -28,8 +28,13 @@ using json = nlohmann::json;
 
 // Ganache test
 static const char* URL = "127.0.0.1:7545";
-static const char* CONTRACT_ADDR = "0x9de3744909Ba0587A988E10eE7F73960e224980F";
-static const char* ADDRESS = "0x2a9fe9D9b0dae89C48b8B8F4E008E17f1A1ED4A6";
+
+
+static const char* CONTRACT_ADDR = "0x22D9d6faB361FaA969D2EfDE420472633cBB7B11";
+static const char* ADDRESS = "0x603CB0d1c8ab86E72beb3c7DF564A36D7B85ecD2";
+
+// static const char* CONTRACT_ADDR = "0x9de3744909Ba0587A988E10eE7F73960e224980F";
+// static const char* ADDRESS = "0x2a9fe9D9b0dae89C48b8B8F4E008E17f1A1ED4A6";
 
 // Connect via CloudFlare
 // static const char* URL = "https://cloudflare-eth.com/";

--- a/src/automaton/core/interop/ethereum/eth_contract_curl_test.cc
+++ b/src/automaton/core/interop/ethereum/eth_contract_curl_test.cc
@@ -32,17 +32,17 @@ static const char* URL = "127.0.0.1:7545";
 
 static const char* CONTRACT_ADDR = "0x22D9d6faB361FaA969D2EfDE420472633cBB7B11";
 static const char* ADDRESS = "0x603CB0d1c8ab86E72beb3c7DF564A36D7B85ecD2";
+static const char* PRIVATE_KEY = "56aac550d97013a8402c98e3b2aeb20482d19f142a67022d2ab357eb8bb673b0";
 
 // static const char* CONTRACT_ADDR = "0x9de3744909Ba0587A988E10eE7F73960e224980F";
 // static const char* ADDRESS = "0x2a9fe9D9b0dae89C48b8B8F4E008E17f1A1ED4A6";
+// static const char* PRIVATE_KEY = "11937405a1975b68ff0e0fc7e3eedcf21e953113b35f95af30839b44b4960c99";
 
 // Connect via CloudFlare
 // static const char* URL = "https://cloudflare-eth.com/";
 // static const char* CONTRACT_ADDR = "...";
 // static const char* ADDRESS = "0x5a0b54d5dc17e0aadc383d2db43b0a0d3e029c4c";
 
-static const char* PRIVATE_KEY = "56aac550d97013a8402c98e3b2aeb20482d19f142a67022d2ab357eb8bb673b0";
-// static const char* PRIVATE_KEY = "11937405a1975b68ff0e0fc7e3eedcf21e953113b35f95af30839b44b4960c99";
 
 static const char* JSON_FILE = "../contracts/koh/build/contracts/KingAutomaton.json";
 
@@ -110,10 +110,11 @@ int main() {
 
   s = eth_getCode(URL, CONTRACT_ADDR);
   if (s.code == automaton::core::common::status::OK) {
-    if (s.msg == "0x") {
+    if (s.msg == "") {
       std::cout << "Contract NOT FOUND!" << std::endl;
+      return 1;
     } else {
-      std::cout << "Code: " << s.msg.substr(2) << " [...]" << std::endl;
+      std::cout << "Code: " << s.msg.substr(0, std::min<size_t>(64, s.msg.size())) << "..." << std::endl;
     }
   } else {
     std::cout << "Error (eth_getCode()) " << s << std::endl;

--- a/src/automaton/core/interop/ethereum/eth_contract_curl_test.cc
+++ b/src/automaton/core/interop/ethereum/eth_contract_curl_test.cc
@@ -105,7 +105,6 @@ int main() {
 
   s = eth_getCode(URL, CONTRACT_ADDR);
   if (s.code == automaton::core::common::status::OK) {
-    std::cout << s.msg << std::endl;
     if (s.msg == "0x") {
       std::cout << "Contract NOT FOUND!" << std::endl;
     } else {

--- a/src/automaton/core/interop/ethereum/eth_helper_functions.h
+++ b/src/automaton/core/interop/ethereum/eth_helper_functions.h
@@ -32,7 +32,6 @@ static size_t curl_callback(void *contents, size_t size, size_t nmemb, std::stri
 }
 
 static status handle_result(const std::string& result) {
-  std::cout << "RESULT:\n" << result << std::endl;
   json j;
   std::stringstream ss(result);
   try {

--- a/src/automaton/core/interop/ethereum/eth_helper_functions.h
+++ b/src/automaton/core/interop/ethereum/eth_helper_functions.h
@@ -32,9 +32,14 @@ static size_t curl_callback(void *contents, size_t size, size_t nmemb, std::stri
 }
 
 static status handle_result(const std::string& result) {
+  std::cout << "RESULT:\n" << result << std::endl;
   json j;
   std::stringstream ss(result);
-  ss >> j;
+  try {
+    ss >> j;
+  } catch (...) {
+    return status::internal("Could not parse JSON!");
+  }
 
   if (j.find("error") != j.end()) {
     json obj = j["error"];
@@ -64,15 +69,21 @@ static status curl_post(const std::string& url, const std::string& data) {
   LOG(INFO) << "\n======= REQUEST =======\n" << data << "\n=====================";
 
   if (curl) {
+    struct curl_slist *list = NULL;
+
+    list = curl_slist_append(list, "Content-Type: application/json");
+
     curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
     curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, curl_err_buf);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, curl_callback);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &message);
     curl_easy_setopt(curl, CURLOPT_ENCODING, "gzip");
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, list);
 
     curl_err_buf[0] = '\0';
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, data.c_str());
     res = curl_easy_perform(curl);
+    curl_slist_free_all(list);
     if (res != CURLE_OK) {
       size_t len = strlen(curl_err_buf);
       LOG(ERROR) << "Curl result code != CURLE_OK. Result code: " << res;


### PR DESCRIPTION
* Mine key with data from contract
* generate signature + data for claimSlot in eth_contract_curl_test
* handle JSON parse errors
* set Content-Type to "application/json:"
* add "getMinDifficulty" function to contract
